### PR TITLE
First shot at streaming

### DIFF
--- a/PreferencesView.swift
+++ b/PreferencesView.swift
@@ -541,13 +541,154 @@ struct PreferencesView: View {
                 Image(systemName: "keyboard")
                 Text("Hotkeys")
             }
+            
+            // Streaming Settings Tab
+            VStack(spacing: 20) {
+                Text("Streaming & Performance")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                
+                GroupBox("Transcription Mode") {
+                    VStack(alignment: .leading, spacing: 15) {
+                        HStack {
+                            Image(systemName: appState.streamingModeEnabled ? "bolt.fill" : "clock.fill")
+                                .foregroundColor(appState.streamingModeEnabled ? .blue : .orange)
+                                .font(.title2)
+                            
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(appState.streamingModeEnabled ? "Streaming Mode (Recommended)" : "Batch Mode")
+                                    .font(.headline)
+                                Text(appState.streamingModeEnabled ? 
+                                     "Processes audio in real-time chunks for faster results and reduced timeouts" :
+                                     "Processes entire recording at once - may timeout on long recordings")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            
+                            Spacer()
+                            
+                            Toggle("", isOn: $appState.streamingModeEnabled)
+                                .toggleStyle(.switch)
+                        }
+                        
+                        if appState.streamingModeEnabled {
+                            VStack(alignment: .leading, spacing: 8) {
+                                HStack {
+                                    Text("✓ Reduced timeout risk")
+                                    Spacer()
+                                }
+                                HStack {
+                                    Text("✓ Faster partial results")
+                                    Spacer()
+                                }
+                                HStack {
+                                    Text("✓ Better for long recordings")
+                                    Spacer()
+                                }
+                            }
+                            .font(.caption)
+                            .foregroundColor(.green)
+                            .padding(.top, 5)
+                        }
+                    }
+                    .padding()
+                }
+                
+                GroupBox("Partial Results") {
+                    VStack(alignment: .leading, spacing: 15) {
+                        HStack {
+                            Image(systemName: appState.partialResultsEnabled ? "text.bubble.fill" : "text.bubble")
+                                .foregroundColor(appState.partialResultsEnabled ? .green : .gray)
+                                .font(.title2)
+                            
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Real-time Text Updates")
+                                    .font(.headline)
+                                Text(appState.partialResultsEnabled ? 
+                                     "See text appear as you speak (requires Streaming Mode)" :
+                                     "Wait for complete transcription")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            
+                            Spacer()
+                            
+                            Toggle("", isOn: $appState.partialResultsEnabled)
+                                .toggleStyle(.switch)
+                                .disabled(!appState.streamingModeEnabled)
+                        }
+                        
+                        if !appState.streamingModeEnabled {
+                            Text("Enable Streaming Mode to use partial results")
+                                .font(.caption)
+                                .foregroundColor(.orange)
+                                .italic()
+                        }
+                    }
+                    .padding()
+                }
+                
+                GroupBox("Streaming Information") {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("How Streaming Works:")
+                            .font(.headline)
+                        
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack {
+                                Text("1.")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                Text("Audio is processed in smart chunks (1-10 seconds)")
+                            }
+                            
+                            HStack {
+                                Text("2.")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                Text("Voice activity detection prevents splitting words")
+                            }
+                            
+                            HStack {
+                                Text("3.")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                Text("Chunks are sent to API as you speak")
+                            }
+                            
+                            HStack {
+                                Text("4.")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                Text("Results are combined for final transcription")
+                            }
+                        }
+                        
+                        Divider()
+                        
+                        HStack {
+                            Image(systemName: "info.circle.fill")
+                                .foregroundColor(.blue)
+                            Text("Streaming reduces timeout errors especially for long recordings, making VTS more reliable.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    .padding()
+                }
+                
+                Spacer()
+            }
+            .padding()
+            .tabItem {
+                Image(systemName: "waveform.circle.fill")
+                Text("Streaming")
+            }
         }
         .frame(width: 600, height: 600)
         .sheet(isPresented: $showingTestInjectionView) {
             TextInjectionTestView(isPresented: $showingTestInjectionView)
                 .environmentObject(appState)
         }
-
     }
     
     private func saveAPIKey(for provider: STTProviderType) {

--- a/VTSApp/VTS/Protocols/STTProvider.swift
+++ b/VTSApp/VTS/Protocols/STTProvider.swift
@@ -11,12 +11,85 @@ public protocol STTProvider {
     func validateConfig(_ config: ProviderConfig) throws
 }
 
+// New streaming protocol for chunked transcription with partial results
+public protocol StreamingSTTProvider: STTProvider {
+    func transcribeStreaming(
+        stream: AsyncThrowingStream<Data, Error>,
+        config: ProviderConfig,
+        onPartialResult: @escaping (String) -> Void
+    ) async throws -> String
+}
+
+// Voice Activity Detection for intelligent buffering
+public class VoiceActivityDetector {
+    private let silenceThreshold: Float = 0.01
+    private let minChunkDuration: TimeInterval = 1.0 // Minimum 1 second chunks
+    private let maxChunkDuration: TimeInterval = 10.0 // Maximum 10 seconds to prevent timeouts
+    private let silenceTimeout: TimeInterval = 2.0 // 2 seconds of silence ends a chunk
+    
+    private var lastVoiceActivity: Date?
+    private var chunkStartTime: Date?
+    
+    public init() {}
+    
+    public func shouldSendChunk(audioLevel: Float, chunkDuration: TimeInterval) -> ChunkDecision {
+        let now = Date()
+        let hasVoice = audioLevel > silenceThreshold
+        
+        if hasVoice {
+            lastVoiceActivity = now
+            if chunkStartTime == nil {
+                chunkStartTime = now
+            }
+        }
+        
+        // Force send if we've reached max duration
+        if chunkDuration >= maxChunkDuration {
+            return .sendAndReset
+        }
+        
+        // Send if we have enough audio and recent silence
+        if let lastVoice = lastVoiceActivity,
+           chunkDuration >= minChunkDuration,
+           now.timeIntervalSince(lastVoice) >= silenceTimeout {
+            return .sendAndReset
+        }
+        
+        // Continue collecting
+        return .continueCollecting
+    }
+    
+    public func reset() {
+        lastVoiceActivity = nil
+        chunkStartTime = nil
+    }
+}
+
+public enum ChunkDecision {
+    case continueCollecting       // Keep collecting audio
+    case sendAndReset   // Send current chunk and start new one
+}
+
+// Audio chunk for streaming
+public struct AudioChunk {
+    let data: Data
+    let timestamp: Date
+    let duration: TimeInterval
+    
+    public init(data: Data, timestamp: Date = Date(), duration: TimeInterval) {
+        self.data = data
+        self.timestamp = timestamp
+        self.duration = duration
+    }
+}
+
 public enum STTError: Error, LocalizedError, Equatable {
     case invalidAPIKey
     case invalidModel
     case networkError(String)
     case audioProcessingError(String)
     case transcriptionError(String)
+    case chunkProcessingError(String)
     
     public static func == (lhs: STTError, rhs: STTError) -> Bool {
         switch (lhs, rhs) {
@@ -28,6 +101,8 @@ public enum STTError: Error, LocalizedError, Equatable {
         case (.audioProcessingError(let lhsMessage), .audioProcessingError(let rhsMessage)):
             return lhsMessage == rhsMessage
         case (.transcriptionError(let lhsMessage), .transcriptionError(let rhsMessage)):
+            return lhsMessage == rhsMessage
+        case (.chunkProcessingError(let lhsMessage), .chunkProcessingError(let rhsMessage)):
             return lhsMessage == rhsMessage
         default:
             return false
@@ -46,6 +121,8 @@ public enum STTError: Error, LocalizedError, Equatable {
             return "Audio processing error: \(message)"
         case .transcriptionError(let message):
             return "Transcription error: \(message)"
+        case .chunkProcessingError(let message):
+            return "Chunk processing error: \(message)"
         }
     }
 }

--- a/VTSApp/VTS/Providers/GroqProvider.swift
+++ b/VTSApp/VTS/Providers/GroqProvider.swift
@@ -1,21 +1,28 @@
 import Foundation
 
-public class GroqProvider: STTProvider {
+public class GroqProvider: StreamingSTTProvider {
     public let providerType: STTProviderType = .groq
     
     private let baseURL = "https://api.groq.com/openai/v1"
-    private let session = URLSession.shared
+    private let session: URLSession
     
-    public init() {}
+    public init() {
+        // Configure URLSession with appropriate timeouts for streaming
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 30.0  // 30 seconds per request
+        config.timeoutIntervalForResource = 300.0 // 5 minutes total
+        self.session = URLSession(configuration: config)
+    }
     
+    // MARK: - Original batch interface (maintained for compatibility)
     public func transcribe(
         stream: AsyncThrowingStream<Data, Error>,
         config: ProviderConfig
     ) async throws -> String {
+        // For backward compatibility, collect all audio and send as batch
         var audioData = Data()
         print("Groq: Starting audio collection...")
         
-        // Collect audio data for batch processing
         for try await chunk in stream {
             audioData.append(chunk)
             print("Groq: Received audio chunk of \(chunk.count) bytes, total: \(audioData.count)")
@@ -23,19 +30,119 @@ public class GroqProvider: STTProvider {
         
         print("Groq: Audio collection completed, total size: \(audioData.count) bytes")
         
-        // Only send if we have enough audio data (at least 1 second worth)
+        // Only send if we have enough audio data
         let minimumBytes = Int(16000 * 2) // 1 second of 16kHz 16-bit audio
         guard audioData.count >= minimumBytes else {
             print("Groq: Not enough audio data (\(audioData.count) bytes, minimum: \(minimumBytes))")
             throw STTError.audioProcessingError("Not enough audio data")
         }
         
-        // Send to Groq and return result directly
-        print("Groq: Sending transcription request...")
-        let result = try await sendTranscriptionRequest(audioData: audioData, config: config)
-        print("Groq: Received transcription result: \(result)")
+        return try await sendTranscriptionRequest(audioData: audioData, config: config)
+    }
+    
+    // MARK: - New streaming interface with chunked processing
+    public func transcribeStreaming(
+        stream: AsyncThrowingStream<Data, Error>,
+        config: ProviderConfig,
+        onPartialResult: @escaping (String) -> Void
+    ) async throws -> String {
+        print("Groq: Starting streaming transcription...")
         
-        return result
+        let vad = VoiceActivityDetector()
+        var currentChunk = Data()
+        var allTranscriptions: [String] = []
+        var chunkStartTime = Date()
+        var lastAudioLevel: Float = 0.0
+        
+        // Process audio stream in chunks
+        for try await audioData in stream {
+            currentChunk.append(audioData)
+            
+            // Calculate approximate audio level for VAD
+            lastAudioLevel = calculateAudioLevel(from: audioData)
+            let chunkDuration = Date().timeIntervalSince(chunkStartTime)
+            
+            // Check if we should send this chunk
+            let decision = vad.shouldSendChunk(audioLevel: lastAudioLevel, chunkDuration: chunkDuration)
+            
+            switch decision {
+            case .continueCollecting:
+                // Keep collecting audio
+                continue
+                
+            case .sendAndReset:
+                // Send current chunk if it has enough data
+                if currentChunk.count >= Int(16000 * 0.5 * 2) { // At least 0.5 seconds
+                    print("Groq: Sending chunk of \(currentChunk.count) bytes after \(chunkDuration) seconds")
+                    
+                    do {
+                        let chunkResult = try await sendTranscriptionRequest(
+                            audioData: currentChunk, 
+                            config: config
+                        )
+                        
+                        if !chunkResult.trimmingCharacters(in: .whitespaces).isEmpty {
+                            allTranscriptions.append(chunkResult)
+                            print("Groq: Partial result: \(chunkResult)")
+                            
+                            // Send partial result to callback
+                            onPartialResult(chunkResult)
+                        }
+                    } catch {
+                        print("Groq: Error processing chunk: \(error)")
+                        // Continue processing instead of failing completely
+                    }
+                }
+                
+                // Reset for next chunk
+                currentChunk = Data()
+                chunkStartTime = Date()
+                vad.reset()
+            }
+        }
+        
+        // Process any remaining audio data
+        if currentChunk.count >= Int(16000 * 0.5 * 2) {
+            print("Groq: Processing final chunk of \(currentChunk.count) bytes")
+            
+            do {
+                let finalResult = try await sendTranscriptionRequest(
+                    audioData: currentChunk, 
+                    config: config
+                )
+                
+                if !finalResult.trimmingCharacters(in: .whitespaces).isEmpty {
+                    allTranscriptions.append(finalResult)
+                    onPartialResult(finalResult)
+                }
+            } catch {
+                print("Groq: Error processing final chunk: \(error)")
+            }
+        }
+        
+        // Combine all transcription results
+        let finalTranscription = allTranscriptions.joined(separator: " ")
+        print("Groq: Final combined transcription: \(finalTranscription)")
+        
+        return finalTranscription.isEmpty ? "No speech detected" : finalTranscription
+    }
+    
+    // MARK: - Helper methods
+    private func calculateAudioLevel(from audioData: Data) -> Float {
+        // Simple audio level calculation
+        guard audioData.count >= 2 else { return 0.0 }
+        
+        let samples = audioData.withUnsafeBytes { bytes in
+            bytes.bindMemory(to: Int16.self)
+        }
+        
+        var sum: Float = 0.0
+        for sample in samples {
+            sum += abs(Float(sample))
+        }
+        
+        let average = sum / Float(samples.count)
+        return average / Float(Int16.max) // Normalize to 0-1
     }
     
     public func validateConfig(_ config: ProviderConfig) throws {
@@ -49,6 +156,41 @@ public class GroqProvider: STTProvider {
     }
     
     private func sendTranscriptionRequest(audioData: Data, config: ProviderConfig) async throws -> String {
+        // Add retry logic for better reliability
+        let maxRetries = 3
+        var lastError: Error?
+        
+        for attempt in 1...maxRetries {
+            do {
+                return try await performTranscriptionRequest(audioData: audioData, config: config)
+            } catch let error as STTError {
+                lastError = error
+                print("Groq: Attempt \(attempt)/\(maxRetries) failed: \(error)")
+                
+                // Don't retry on certain errors
+                switch error {
+                case .invalidAPIKey, .invalidModel:
+                    throw error
+                default:
+                    if attempt < maxRetries {
+                        // Exponential backoff
+                        try await Task.sleep(nanoseconds: UInt64(pow(2.0, Double(attempt)) * 1_000_000_000))
+                    }
+                }
+            } catch {
+                lastError = error
+                print("Groq: Attempt \(attempt)/\(maxRetries) failed: \(error)")
+                
+                if attempt < maxRetries {
+                    try await Task.sleep(nanoseconds: UInt64(pow(2.0, Double(attempt)) * 1_000_000_000))
+                }
+            }
+        }
+        
+        throw lastError ?? STTError.transcriptionError("All retry attempts failed")
+    }
+    
+    private func performTranscriptionRequest(audioData: Data, config: ProviderConfig) async throws -> String {
         var request = URLRequest(url: URL(string: "\(baseURL)/audio/transcriptions")!)
         request.httpMethod = "POST"
         request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
@@ -98,17 +240,25 @@ public class GroqProvider: STTProvider {
         
         let (data, response) = try await session.data(for: request)
         
-        guard let httpResponse = response as? HTTPURLResponse,
-              200...299 ~= httpResponse.statusCode else {
-            throw STTError.networkError("Bad server response")
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw STTError.networkError("Invalid response type")
+        }
+        
+        guard 200...299 ~= httpResponse.statusCode else {
+            let errorMessage = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw STTError.networkError("HTTP \(httpResponse.statusCode): \(errorMessage)")
         }
         
         struct TranscriptionResponse: Codable {
             let text: String
         }
         
-        let transcriptionResponse = try JSONDecoder().decode(TranscriptionResponse.self, from: data)
-        return transcriptionResponse.text
+        do {
+            let transcriptionResponse = try JSONDecoder().decode(TranscriptionResponse.self, from: data)
+            return transcriptionResponse.text
+        } catch {
+            throw STTError.transcriptionError("Failed to decode response: \(error)")
+        }
     }
     
     private func createWAVData(from pcmData: Data) -> Data {


### PR DESCRIPTION
**2 Issues with this streaming implementation:**


1. We need to improve voice activity detection and or noise detection. See this, I'm not sure what happened in the end (maybe noise or maybe wrongly recognized voice activity) but it generated noise text (some chinese words). Also a lot of sentences cut mid-sentence by a punctuation mark or similar (result example: `My goal wasn't to send chunk of audios.  for the AI to transcribe`).

<details>


```
Yielding audio data: 3200 bytes
Audio level: 0.076022804
Yielding audio data: 3200 bytes
Audio level: 0.03583413
Yielding audio data: 3200 bytes
Audio level: 0.021024693
Yielding audio data: 3200 bytes
Audio level: 0.012822129
Global recording hotkey pressed!
Recording stopped - transcription will continue processing
Groq: Partial result:  Puedo contar cuentos grandes, cuentos del tamaño de la luna, cuentos como “el mar y el infinito, “cuentos que se desatan de tormentas inexorables y maestros.
📝 TranscriptionService: Partial result: 'Puedo contar cuentos grandes, cuentos del tamaño de la luna, cuentos como “el mar y el infinito, “cuentos que se desatan de tormentas inexorables y maestros.'
📝 TranscriptionService: Partial result stored in memory only
Groq: Processing final chunk of 22400 bytes
nw_resolver_start_query_timer_block_invoke [C3.1.1] Query fired: did not receive all answers in time for api.groq.com:443
Groq: Final combined transcription:  Puedo contar cuentos grandes, cuentos del tamaño de la luna, cuentos como “el mar y el infinito, “cuentos que se desatan de tormentas inexorables y maestros. これにていって� Youth it …
📝 TranscriptionService: Partial result: 'これにていって� Youth it …'
📝 TranscriptionService: Partial result stored in memory only
🎙️ TranscriptionService: Received final result: ' Puedo contar cuentos grandes, cuentos del tamaño de la luna, cuentos como “el mar y el infinito, “cuentos que se desatan de tormentas inexorables y maestros. これにていって� Youth it …'
🎙️ TranscriptionService: Final text after trimming: 'Puedo contar cuentos grandes, cuentos del tamaño de la luna, cuentos como “el mar y el infinito, “cuentos que se desatan de tormentas inexorables y maestros. これにていって� Youth it …'
```

</details>

2.  My original goal was to actually stream the file contents while the user speaks, so we don't have to wait for the user to stop speaking for us to upload the whole file. My goal wasn't to send small audio files for the model to transcribe each entirely. So maybe exploring these actual solutions in the future would be worth it, see `Deepgram` [or others](https://g.co/gemini/share/2e149a5daa91). 


**[update 30/08/2025]** I was poking around with some workaround ideas for this before moving to actual OpenAI or similar real-time API implementation, these ideas were discarded in favor of the OpenAI real-time WebSockets or similar implementations:

<details>

j05u3: Using the current API endpoint for OpenAI, can we stream the file contents while the user speaks? so we don't have to wait for the user to stop speaking for us to start uploading the file .

Make a plan and generate ideas but do not implement nor modify anything yet

GitHub Copilot: I'll analyze the current VTS project to understand the OpenAI integration and explore how we can implement streaming of audio file contents while the user is speaking. Let me first examine the codebase to understand the current implementation. Now let me check the base provider to understand the current architecture: Now let me check the CaptureEngine to see how audio is currently captured: Now let me check the STT provider protocol to understand the interface: Let me also check the models to understand the configuration structure: Now let me look at how OpenAI's API documentation describes streaming for Whisper to understand the limitations: Let me search for more specific information about OpenAI's API streaming capabilities: Now let me get the official OpenAI Realtime API documentation: Let me search for more detailed API documentation: Perfect! Now I have a comprehensive understanding of the current architecture and OpenAI's capabilities. Let me create a detailed plan and analysis.

## Analysis and Plan for Streaming Audio to OpenAI

Based on my analysis of the VTS codebase and OpenAI's API capabilities, here's my comprehensive plan for implementing streaming audio transcription:

### Current Architecture Analysis

**Existing Implementation:**
- Uses OpenAI's REST API (`/v1/audio/transcriptions`) with multipart/form-data
- Collects entire audio stream into memory before sending
- Waits for user to finish speaking before uploading
- Uses traditional `whisper-1` model

**Current Flow:**
1. `CaptureEngine` streams audio chunks via `AsyncThrowingStream<Data, Error>`
2. `OpenAIProvider.transcribe()` collects all chunks into a single `Data` object
3. Converts to WAV format and uploads complete file
4. Returns transcription result

### OpenAI's Streaming Capabilities

**Two Approaches Available:**

1. **Traditional REST API** (current approach)
   - Limited to complete file uploads
   - Maximum file size: 25MB
   - Models: `whisper-1`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`
   - No real-time streaming capability

2. **Realtime API** (NEW - streaming solution)
   - WebSocket-based: `wss://api.openai.com/v1/realtime?intent=transcription`
   - Real-time audio streaming with `input_audio_buffer.append` events
   - Models: `gpt-4o-transcribe`, `gpt-4o-mini-transcribe` (NOT `whisper-1`)
   - Audio format: PCM16, 16kHz or 24kHz mono
   - Base64-encoded audio chunks sent continuously
   - Receives `conversation.item.input_audio_transcription.delta` and `completed` events

### Implementation Plan

#### **Phase 1: Create New Streaming Provider Architecture**

1. **Extend Protocol to Support Streaming**
   ```swift
   // Add streaming capability to STTProvider protocol
   func transcribeStream(
       stream: AsyncThrowingStream<Data, Error>,
       config: ProviderConfig
   ) async throws -> AsyncThrowingStream<TranscriptionChunk, Error>
   ```

2. **Create OpenAI Realtime Provider**
   - New class: `OpenAIRealtimeProvider: BaseSTTProvider`
   - WebSocket connection management
   - Audio chunk streaming with base64 encoding
   - Real-time transcription result handling

#### **Phase 2: WebSocket Infrastructure**

1. **WebSocket Manager**
   ```swift
   class RealtimeWebSocketManager {
       private var webSocketTask: URLSessionWebSocketTask?
       private var continuation: AsyncThrowingStream<TranscriptionChunk, Error>.Continuation?
       
       func connect(apiKey: String, model: String) async throws
       func sendAudioChunk(_ audioData: Data) async throws
       func handleIncomingMessage(_ message: URLSessionWebSocketTask.Message)
       func disconnect()
   }
   ```

2. **Audio Format Conversion**
   - Convert VTS's 16kHz PCM16 audio to base64
   - Handle the audio format requirements (PCM16, 16kHz mono)
   - Chunk size optimization for network efficiency

#### **Phase 3: Integration Strategy**

1. **Dual Provider Support**
   - Keep existing `OpenAIProvider` for traditional models (`whisper-1`)
   - Add `OpenAIRealtimeProvider` for streaming models (`gpt-4o-transcribe`, `gpt-4o-mini-transcribe`)
   - Provider selection based on model choice

2. **Model Configuration Updates**
   ```swift
   public enum STTProviderType: String, CaseIterable {
       case openai = "OpenAI"
       case openaiRealtime = "OpenAI Realtime"
       // ...
       
       public var defaultModels: [String] {
           switch self {
           case .openai:
               return ["whisper-1"] // Traditional REST API
           case .openaiRealtime:
               return ["gpt-4o-transcribe", "gpt-4o-mini-transcribe"] // Realtime API
           // ...
           }
       }
   }
   ```

#### **Phase 4: Real-time Transcription Features**

1. **Progressive Results**
   - Handle `conversation.item.input_audio_transcription.delta` for partial transcriptions
   - Handle `conversation.item.input_audio_transcription.completed` for final results
   - Update UI progressively as transcription arrives

2. **Voice Activity Detection (VAD)**
   - Optional VAD configuration
   - Automatic speech boundary detection
   - Configurable turn detection settings

#### **Phase 5: Advanced Features**

1. **Chunking Strategy**
   - Implement smart audio chunking based on silence detection
   - Buffer management for network efficiency
   - Error recovery and reconnection logic

2. **Audio Quality Optimizations**
   - Noise reduction configuration (`near_field` vs `far_field`)
   - Audio quality adaptation based on connection
   - Compression options for bandwidth optimization

### Technical Considerations

#### **Advantages of Streaming Approach:**
- **Immediate Feedback**: Transcription starts appearing while user is speaking
- **Lower Latency**: No need to wait for complete audio capture
- **Better UX**: Progressive transcription display
- **Memory Efficiency**: No need to buffer entire audio in memory
- **Real-time Applications**: Enables live captioning scenarios

#### **Implementation Challenges:**
1. **WebSocket Management**: Connection lifecycle, reconnection logic
2. **Audio Synchronization**: Maintaining audio chunk order and timing
3. **Error Handling**: Network interruptions, API limits
4. **State Management**: Managing multiple concurrent streams
5. **Audio Format**: Ensuring compatibility with OpenAI's requirements

#### **Architecture Changes Required:**
1. **Protocol Extension**: Add streaming methods to `STTProvider`
2. **UI Updates**: Handle progressive transcription display
3. **Configuration**: New provider type and model selection
4. **Error Handling**: WebSocket-specific error types
5. **Testing**: Mock WebSocket connections for unit tests

### Backward Compatibility

- Maintain existing `OpenAIProvider` for `whisper-1` model
- Add new `OpenAIRealtimeProvider` as optional enhancement
- Users can choose between traditional and streaming approaches
- Gradual migration path for existing configurations

This plan provides a comprehensive approach to implementing real-time streaming transcription while maintaining the existing architecture's flexibility and adding significant user experience improvements through immediate transcription feedback.

j05u3: Please explain to me why traditional REST API (current approach) is Limited to complete file uploads while, I mean can I convert chunks of audio to WAV and start sending to that REST API right after I have the first chunk of audio from the user? Do we need to send a header or something that contains a hash or some value that depends on the complete audio file?

The total audio recording duration is 4 seconds on average and can go up to around 12 seconds.

GitHub Copilot: Great question! Let me explain why the traditional REST API is limited to complete file uploads and whether we can work around this limitation.

## Why REST API Requires Complete Files

Let me first examine the current WAV creation implementation to understand the technical constraints: Now let me check how the current OpenAI provider uses this: Perfect! Now I can explain the technical constraints clearly.

## Why Traditional REST API Requires Complete Files

The limitation comes from **three fundamental technical constraints**:

### 1. **WAV File Format Structure Requirements**

Looking at the `createWAVData` method, you can see the issue:

```swift
let dataSize = UInt32(pcmData.count)  // ← NEEDS TOTAL SIZE
let fileSize = 36 + dataSize          // ← NEEDS TOTAL SIZE

// RIFF header
wavData.append("RIFF".data(using: .ascii)!)
var fileSizeLE = fileSize.littleEndian    // ← WRITTEN AT THE BEGINNING
wavData.append(Data(bytes: &fileSizeLE, count: 4))

// ... later in the file ...
// data chunk
wavData.append("data".data(using: .ascii)!)
var dataSizeLE = dataSize.littleEndian    // ← WRITTEN BEFORE AUDIO DATA
wavData.append(Data(bytes: &dataSizeLE, count: 4))
wavData.append(pcmData)
```

**The Problem**: WAV files require the **total file size** and **total audio data size** to be written **at the beginning** of the file, but we don't know these values until we've collected all the audio chunks.

### 2. **HTTP Multipart Form Structure**

The OpenAI API expects a multipart/form-data request:

```swift
body.append("Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n")
body.append("Content-Type: audio/wav\r\n\r\n")
body.append(createWAVData(from: audioData))  // ← Complete WAV file expected
```

**The Problem**: HTTP multipart doesn't have a standard way to stream file content. The `Content-Length` header for the entire request needs to be known upfront.

### 3. **OpenAI API Design**

The `/v1/audio/transcriptions` endpoint is designed as a **file upload API**, not a streaming API. It expects:
- A complete, valid audio file
- Standard HTTP POST with known content length
- The entire audio content available at request time

## Could We Work Around This?

### **Potential Workarounds (and why they don't work well):**

#### Option 1: Send Individual Chunks as Separate Requests
```swift
// Send each chunk as a separate WAV file
for chunk in audioChunks {
    let wavData = createWAVData(from: chunk)
    let transcription = try await sendToOpenAI(wavData)
    // Combine results somehow
}
```

**Problems:**
- **Loss of context**: Each chunk is transcribed independently
- **Word boundary issues**: Words might be cut off between chunks
- **Higher cost**: Multiple API calls
- **Latency**: Still need to wait for each chunk to complete
- **Poor accuracy**: Short audio snippets are harder to transcribe accurately

#### Option 2: Streaming WAV with Unknown Length
Some containers support streaming, but WAV doesn't handle this well, and OpenAI's API doesn't support it.

#### Option 3: Use Raw PCM Instead of WAV
```swift
// Hypothetically send raw PCM data
body.append("Content-Type: audio/pcm\r\n\r\n")
body.append(pcmData)  // Raw audio without headers
```

**Problems:**
- OpenAI API specifically expects WAV format
- Even if it accepted PCM, it would still need to know the total length upfront
- No metadata about sample rate, channels, etc.

### **Why 4-12 Seconds Still Requires Complete Files:**

Even with your relatively short audio durations:

1. **WAV header constraint remains**: You still can't write the file size until you have all the data
2. **HTTP multipart limitation**: The request needs a known `Content-Length`
3. **API design**: OpenAI's REST endpoint fundamentally expects complete files

### **Real Numbers for Your Use Case:**

For your 4-12 second recordings at 16kHz, 16-bit, mono:
- **4 seconds**: ~128KB of audio data
- **12 seconds**: ~384KB of audio data

These are small enough that the traditional approach isn't a major bottleneck, but you're still missing the **user experience benefit** of seeing transcription appear in real-time.

## The Solution: OpenAI's Realtime API

This is exactly why OpenAI created the Realtime API:

```javascript
// WebSocket - can send chunks immediately
{
    "type": "input_audio_buffer.append",
    "audio": "base64EncodedChunk"  // ← Individual chunk, no file headers needed
}
```

**Key differences:**
- **No file format constraints**: Sends raw audio chunks as base64
- **WebSocket protocol**: Designed for streaming
- **Real-time processing**: Server processes chunks as they arrive
- **Progressive results**: Get transcription deltas while speaking

## Conclusion

You **cannot** effectively stream to the traditional REST API because:

1. **WAV format requires total size upfront** (written in headers)
2. **HTTP multipart needs known content length**
3. **OpenAI's REST API is designed for complete files**

For your 4-12 second use case, the current approach works fine **functionally**, but you're missing the **UX benefit** of real-time transcription feedback. The Realtime API is the proper solution for true streaming transcription.

j05u3: What if we send in the content length and in the WAV file header a potential reasonable upper bound (e.g.: 384 kilobytes in the content length) and then we fill the file with dummy bytes so we actually make it to that upper bound

GitHub Copilot: That's a clever workaround idea! Let me analyze the technical feasibility and implications of this approach.

## The "Pre-allocated WAV with Padding" Approach

Your idea would work like this:

```swift
// 1. Pre-allocate WAV with maximum size
let maxDuration: Double = 12.0  // seconds
let maxSamples = Int(16000 * maxDuration * 1)  // 16kHz, mono
let maxAudioBytes = maxSamples * 2  // 16-bit = 2 bytes per sample
let maxWAVSize = 44 + maxAudioBytes  // WAV header + audio data

// 2. Create WAV with dummy data
var wavData = createWAVWithPadding(maxSize: maxWAVSize)

// 3. Start HTTP request with known Content-Length
request.setValue("\(totalRequestSize)", forHTTPHeaderField: "Content-Length")

// 4. Stream: Send multipart headers, then WAV header, then real audio + padding
```

## Technical Analysis

### ✅ **It Could Work Technically**

```swift
func createPreallocatedWAV(maxDurationSeconds: Double) -> (Data, Int) {
    let sampleRate: UInt32 = 16000
    let channels: UInt16 = 1
    let bitsPerSample: UInt16 = 16
    
    // Calculate maximum audio data size
    let maxSamples = Int(Double(sampleRate) * maxDurationSeconds)
    let maxAudioBytes = maxSamples * Int(bitsPerSample / 8)
    let maxFileSize = 36 + UInt32(maxAudioBytes)
    
    var wavData = Data()
    
    // RIFF header with MAX size
    wavData.append("RIFF".data(using: .ascii)!)
    var fileSizeLE = maxFileSize.littleEndian
    wavData.append(Data(bytes: &fileSizeLE, count: 4))
    wavData.append("WAVE".data(using: .ascii)!)
    
    // fmt chunk (same as before)
    // ... fmt chunk code ...
    
    // data chunk with MAX size
    wavData.append("data".data(using: .ascii)!)
    var dataSizeLE = UInt32(maxAudioBytes).littleEndian
    wavData.append(Data(bytes: &dataSizeLE, count: 4))
    
    // Reserve space for audio data (initially zeros/silence)
    wavData.append(Data(count: maxAudioBytes))  // All zeros = silence
    
    return (wavData, 44)  // Return WAV and header size
}
```

Then during streaming:
```swift
func streamAudioToPreallocatedWAV() async throws {
    let (wavData, headerSize) = createPreallocatedWAV(maxDurationSeconds: 12.0)
    
    // Start HTTP request with known size
    var request = URLRequest(url: transcriptionURL)
    request.httpMethod = "POST"
    request.setValue("\(multipartBodySize)", forHTTPHeaderField: "Content-Length")
    
    // Stream the data
    var audioOffset = headerSize
    for try await audioChunk in audioStream {
        // Replace silence with real audio data
        wavData.replaceSubrange(audioOffset..<(audioOffset + audioChunk.count), 
                               with: audioChunk)
        audioOffset += audioChunk.count
    }
    
    // Send the complete WAV (with remaining silence at the end)
    // ...
}
```

### ⚠️ **Major Problems with This Approach**

#### 1. **HTTP Streaming Complexity**
```swift
// You'd need to implement chunked transfer or custom streaming
let session = URLSession(configuration: .default)
let task = session.uploadTask(with: request) { data, response, error in
    // But you need to send data as it becomes available
    // This is complex with URLSession
}
```

**Problem**: iOS's `URLSession` doesn't easily support "streaming upload where you gradually replace bytes in a pre-allocated buffer." You'd need complex custom networking.

#### 2. **Waste of Bandwidth and Processing**
```
Real audio:     4 seconds  = ~128KB
Padded WAV:    12 seconds  = ~384KB
Waste:         8 seconds  = ~256KB (66% waste!)
```

For 4-second recordings, you're sending **3x more data than necessary**.

#### 3. **OpenAI Processing Inefficiency**
```swift
// OpenAI receives:
// [Real speech: 4s] + [Silence: 8s] = 12s total
// 
// Processing time and cost based on 12s, not 4s
```

**Problems**:
- OpenAI charges for the full duration processed
- Processing time is based on total audio length
- Their transcription models may try to process the silence

#### 4. **Complex Implementation**
```swift
// You'd need to manage:
class StreamingWAVUploader {
    private var preallocatedBuffer: Data
    private var currentOffset: Int
    private var uploadTask: URLSessionUploadTask?
    private var continuation: CheckedContinuation<String, Error>?
    
    // Complex state management for partial uploads
    // Error handling for network interruptions
    // Buffer management and synchronization
}
```

#### 5. **Silence Might Affect Transcription Quality**
Many speech-to-text models are optimized for actual speech patterns. Long periods of silence might:
- Trigger end-of-speech detection prematurely
- Affect confidence scores
- Interfere with language model context

### 🤔 **A Slightly Better Variant**

If you wanted to try this approach, a better version might be:

```swift
func dynamicChunkUpload() async throws -> String {
    let chunkDuration: Double = 2.0  // 2-second chunks
    var transcriptionParts: [String] = []
    var audioBuffer = Data()
    
    for try await audioChunk in audioStream {
        audioBuffer.append(audioChunk)
        
        // When we have enough for a chunk, send it
        let chunkSamples = Int(16000 * chunkDuration * 2)  // 2 bytes per sample
        if audioBuffer.count >= chunkSamples {
            let chunkData = audioBuffer.prefix(chunkSamples)
            audioBuffer.removeFirst(chunkSamples)
            
            // Send this chunk as a complete WAV file
            let wavChunk = createWAVData(from: Data(chunkData))
            let partialTranscription = try await sendTranscriptionRequest(
                audioData: wavChunk, 
                config: config
            )
            transcriptionParts.append(partialTranscription)
        }
    }
    
    // Send remaining audio if any
    if !audioBuffer.isEmpty {
        let wavChunk = createWAVData(from: audioBuffer)
        let finalTranscription = try await sendTranscriptionRequest(
            audioData: wavChunk, 
            config: config
        )
        transcriptionParts.append(finalTranscription)
    }
    
    return transcriptionParts.joined(separator: " ")
}
```

**This approach**:
- ✅ Sends smaller, complete chunks
- ✅ No bandwidth waste
- ✅ Uses existing API without modification
- ⚠️ Still has word boundary issues
- ⚠️ Multiple API calls = higher cost
- ⚠️ Loss of context between chunks

## Verdict

Your padding idea is **technically possible** but **not practical** because:

1. **Bandwidth waste**: 66% waste for typical 4-second recordings
2. **Cost increase**: OpenAI charges for processing 12 seconds instead of 4
3. **Implementation complexity**: Custom HTTP streaming is non-trivial
4. **Quality concerns**: Long silence periods might affect transcription
5. **No real benefit**: You still don't get real-time transcription feedback

## Better Alternatives

For your 4-12 second use case, I'd recommend:

### **Option 1: Keep Current Approach (Simplest)**
- The UX impact of waiting 4-12 seconds isn't terrible
- Current implementation is simple and reliable
- Focus on other features first

### **Option 2: Implement OpenAI Realtime API (Best UX)**
- True real-time streaming
- Better user experience
- More complex but proper solution

### **Option 3: Hybrid Approach**
- Keep current implementation as fallback
- Add Realtime API for users who want real-time feedback
- Let users choose in settings

The padding approach is clever thinking, but the trade-offs make it impractical compared to these alternatives!

<details/>