### PR TITLE
feat: improve text injection in general by using Unicode typing simulation

### DIFF
--- a/VTSApp/VTS/Controllers/StatusBarController.swift
+++ b/VTSApp/VTS/Controllers/StatusBarController.swift
@@ -207,13 +207,13 @@ public class StatusBarController: ObservableObject {
         // Priority: Recording > Processing > Idle
         if isRecording {
             button.title = "🔴"
-            button.toolTip = "VTS is recording audio - Click to stop (\(hotkey))"
+            button.toolTip = "VTS is recording audio - Press \(hotkey) to stop"
         } else if isProcessing {
             button.title = "🔵"
-            button.toolTip = "VTS is processing audio - Click to view progress (\(hotkey))"
+            button.toolTip = "VTS is processing audio"
         } else {
             button.title = "⚪️"
-            button.toolTip = "VTS is ready - Click to start recording (\(hotkey))"
+            button.toolTip = "VTS is ready - Press \(hotkey) to start recording"
         }
     }
 

--- a/VTSApp/VTS/Services/TextInjector.swift
+++ b/VTSApp/VTS/Services/TextInjector.swift
@@ -191,6 +191,56 @@ public class TextInjector: ObservableObject {
         }
     }
     
+    public func testAccessibilityOnlyInjection() {
+        log("🧪 TextInjector: Starting ACCESSIBILITY API ONLY test...")
+        log("🔬 TextInjector: This test will ONLY use the Accessibility API, no fallback to typing simulation")
+        checkPermissionStatus()
+        
+        if hasAccessibilityPermission {
+            log("🧪 TextInjector: Accessibility-only test will begin in 3 seconds...")
+            log("🧪 TextInjector: Please focus on a text field now!")
+            log("🔬 TextInjector: This test helps diagnose if Accessibility API works in specific apps")
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+                let testText = "ACCESSIBILITY-ONLY: Hello from VTS!"
+                self.log("🔬 TextInjector: Testing ONLY Accessibility API with: '\(testText)'")
+                
+                if self.tryModernAccessibilityInsertion(testText) {
+                    self.log("✅ TextInjector: Accessibility API test SUCCEEDED")
+                } else {
+                    self.log("❌ TextInjector: Accessibility API test FAILED - this app may have broken accessibility support")
+                }
+            }
+        } else {
+            log("🧪 TextInjector: Cannot test - accessibility permission required")
+        }
+    }
+    
+    public func testUnicodeTypingOnlyInjection() {
+        log("🧪 TextInjector: Starting UNICODE TYPING ONLY test...")
+        log("🔬 TextInjector: This test will ONLY use Unicode typing simulation, no Accessibility API")
+        checkPermissionStatus()
+        
+        if hasAccessibilityPermission {
+            log("🧪 TextInjector: Unicode typing-only test will begin in 3 seconds...")
+            log("🧪 TextInjector: Please focus on a text field now!")
+            log("🔬 TextInjector: This test helps verify if typing simulation works when Accessibility API fails")
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+                let testText = "TYPING-ONLY: Hello from VTS!"
+                self.log("🔬 TextInjector: Testing ONLY Unicode typing simulation with: '\(testText)'")
+                
+                if self.simulateModernUnicodeTyping(testText) {
+                    self.log("✅ TextInjector: Unicode typing test SUCCEEDED")
+                } else {
+                    self.log("❌ TextInjector: Unicode typing test FAILED")
+                }
+            }
+        } else {
+            log("🧪 TextInjector: Cannot test - accessibility permission required")
+        }
+    }
+    
     public func requestAccessibilityPermission() {
         print("Requesting accessibility permission for text insertion...")
         

--- a/VTSApp/VTS/Services/TextInjector.swift
+++ b/VTSApp/VTS/Services/TextInjector.swift
@@ -108,35 +108,18 @@ public class TextInjector: ObservableObject {
         }
     }
     
-    public func testCursorInjection() {
-        log("🧪 Starting code editor compatibility test...")
+    public func testEmojiCharacters() {
+        log("🧪 Starting emoji injection test...")
         checkPermissionStatus()
         
         if hasAccessibilityPermission {
-            log("🧪 Code editor test will begin in 3 seconds...")
-            log("🧪 Please focus on a text field in your code editor!")
-            
-            DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
-                // Test with mixed case and international characters
-                self.injectText("Hello World! Testing VTS in code editor. Mixed CaSe TeXt: 123 ABC def. Español: ñáéíóú")
-            }
-        } else {
-            log("🧪 Cannot test - accessibility permission required")
-        }
-    }
-    
-    public func testSpanishCharacters() {
-        log("🧪 Starting international character test...")
-        checkPermissionStatus()
-        
-        if hasAccessibilityPermission {
-            log("🧪 International character test will begin in 3 seconds...")
+            log("🧪 Emoji injection test will begin in 3 seconds...")
             log("🧪 Please focus on any text input field!")
             
             DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
-                let spanishText = "Hola, ¿cómo estás? Me gusta el español: ñáéíóúüÑÁÉÍÓÚÜ"
-                self.log("🧪 Testing international text: '\(spanishText)'")
-                self.injectText(spanishText)
+                let emojiText = "Hello! 😀😃😄😁😆😅😂🤣😊😇🙂👹👺🤡💩👽👾🤖🎃🙀😿😾"
+                self.log("🧪 Testing emoji text: '\(emojiText)'")
+                self.injectText(emojiText)
             }
         } else {
             log("🧪 Cannot test - accessibility permission required")
@@ -164,30 +147,6 @@ public class TextInjector: ObservableObject {
             }
         } else {
             log("🧪 Cannot test - accessibility permission required")
-        }
-    }
-    
-    public func testCursorPositionInsertion() {
-        log("🧪 TextInjector: Starting cursor position insertion test...")
-        checkPermissionStatus()
-        
-        if hasAccessibilityPermission {
-            log("🧪 TextInjector: This test will help verify cursor position insertion works correctly.")
-            log("🧪 TextInjector: Instructions:")
-            log("   1. Focus on a text field")
-            log("   2. Type some text: 'Hello World'")
-            log("   3. Position cursor between 'Hello' and 'World' (middle of the text)")
-            log("   4. Wait for injection in 5 seconds...")
-            log("🧪 TextInjector: Expected result: Text should be inserted AT the cursor, not at the end!")
-            
-            DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
-                let insertText = " INSERTED "
-                self.log("🧪 TextInjector: Inserting '\(insertText)' at cursor position...")
-                self.injectText(insertText)
-                self.log("🧪 TextInjector: If working correctly, text should become: 'Hello INSERTED World'")
-            }
-        } else {
-            log("🧪 TextInjector: Cannot test - no accessibility permission")
         }
     }
     

--- a/VTSApp/VTS/Views/OnboardingSteps/OnboardingAnalyticsStep.swift
+++ b/VTSApp/VTS/Views/OnboardingSteps/OnboardingAnalyticsStep.swift
@@ -3,7 +3,10 @@ import SwiftUI
 struct OnboardingAnalyticsStep: View {
     @ObservedObject var appState: AppState
     @State private var animateContent = false
-    @StateObject private var consentManager = AnalyticsConsentManager.shared
+    
+    private var consentManager: AnalyticsConsentManager {
+        appState.analyticsConsentManagerService
+    }
     
     var body: some View {
         VStack(spacing: 40) {

--- a/VTSApp/VTS/Views/PreferencesView.swift
+++ b/VTSApp/VTS/Views/PreferencesView.swift
@@ -777,19 +777,19 @@ struct PreferencesView: View {
                             Spacer()
                             
                             Toggle("", isOn: Binding(
-                                get: { AnalyticsConsentManager.shared.hasConsent },
+                                get: { appState.analyticsConsentManagerService.hasConsent },
                                 set: { newValue in
                                     if newValue {
-                                        AnalyticsConsentManager.shared.grantConsent()
+                                        appState.analyticsConsentManagerService.grantConsent()
                                     } else {
-                                        AnalyticsConsentManager.shared.revokeConsent()
+                                        appState.analyticsConsentManagerService.revokeConsent()
                                     }
                                 }
                             ))
                             .toggleStyle(.switch)
                         }
                         
-                        if AnalyticsConsentManager.shared.hasConsent {
+                        if appState.analyticsConsentManagerService.hasConsent {
                             HStack {
                                 Image(systemName: "checkmark.circle.fill")
                                     .foregroundColor(.green)

--- a/VTSApp/VTS/Views/TextInjectionTestView.swift
+++ b/VTSApp/VTS/Views/TextInjectionTestView.swift
@@ -72,7 +72,7 @@ struct TextInjectionTestView: View {
                                 .font(.headline)
                             
                             VStack(alignment: .leading, spacing: 8) {
-                                Text("VTS uses multiple text insertion methods for maximum app compatibility:")
+                                Text("VTS may use multiple text insertion methods for maximum app compatibility:")
                                     .font(.body)
                                 
                                 VStack(alignment: .leading, spacing: 6) {
@@ -98,15 +98,6 @@ struct TextInjectionTestView: View {
                                         .padding(.leading, 20)
                                 }
                             }
-                            
-                            Divider()
-                            
-                            Text("Application Compatibility")
-                                .font(.headline)
-                            
-                            Text("VTS automatically detects applications and uses the best insertion method. Some specialized apps like code editors, terminals, and games may require specific handling.")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
                         }
                         .padding()
                     }
@@ -158,35 +149,6 @@ struct TextInjectionTestView: View {
                                 }
                             }
                             
-                            // Application-Specific Tests
-                            VStack(alignment: .leading, spacing: 12) {
-                                Text("Application-Specific Tests")
-                                    .font(.subheadline)
-                                    .fontWeight(.semibold)
-                                
-                                LazyVGrid(columns: [
-                                    GridItem(.flexible()),
-                                    GridItem(.flexible())
-                                ], spacing: 8) {
-                                    TestButton(
-                                        title: "Code Editor Test",
-                                        description: "Optimized for code editors like Cursor",
-                                        action: {
-                                            logMessages.add("🧪 Starting code editor compatibility test...")
-                                            textInjector.testCursorInjection()
-                                        }
-                                    )
-                                    
-                                    TestButton(
-                                        title: "International Text",
-                                        description: "Test Spanish characters & accents",
-                                        action: {
-                                            logMessages.add("🧪 Testing international character support...")
-                                            textInjector.testSpanishCharacters()
-                                        }
-                                    )
-                                }
-                            }
                             
                             // Advanced Tests
                             VStack(alignment: .leading, spacing: 12) {
@@ -208,11 +170,11 @@ struct TextInjectionTestView: View {
                                     )
                                     
                                     TestButton(
-                                        title: "Test Cursor Position",
-                                        description: "Verify insertion at cursor position",
+                                        title: "Emojis",
+                                        description: "Test emojis insertion",
                                         action: {
-                                            logMessages.add("🧪 Testing cursor position insertion...")
-                                            textInjector.testCursorPositionInsertion()
+                                            logMessages.add("🧪 Testing emojis insertion...")
+                                            textInjector.testEmojiCharacters()
                                         }
                                     )
                                 }
@@ -315,9 +277,10 @@ struct TextInjectionTestView: View {
                                 .font(.headline)
                             
                             VStack(alignment: .leading, spacing: 8) {
+                                
                                 TroubleshootingItem(
-                                    issue: "VS Code Terminal: Text injection appears successful but text doesn't appear",
-                                    solution: "VS Code terminal has broken Accessibility API support. Use the diagnostic tests above to confirm - Accessibility API will report success but typing simulation works. This is an Electron/VS Code bug."
+                                    issue: "Permission repeatedly denied or reset",
+                                    solution: "In System Settings > Privacy & Security > Accessibility, remove any old app entries and re-add the current version."
                                 )
                                 
                                 TroubleshootingItem(
@@ -329,10 +292,10 @@ struct TextInjectionTestView: View {
                                     issue: "International characters not displaying correctly",
                                     solution: "Test the international character support. Some applications may require specific input method settings."
                                 )
-                                
+
                                 TroubleshootingItem(
-                                    issue: "Permission repeatedly denied or reset",
-                                    solution: "In System Settings > Privacy & Security > Accessibility, remove any old app entries and re-add the current version."
+                                    issue: "VS Code Terminal: Text injection appears successful but text doesn't appear",
+                                    solution: "VS Code terminal has broken Accessibility API support. Use the diagnostic tests above to confirm - Accessibility API will report success but typing simulation works. This is an Electron/VS Code bug."
                                 )
                                 
                                 TroubleshootingItem(

--- a/VTSApp/VTS/Views/TextInjectionTestView.swift
+++ b/VTSApp/VTS/Views/TextInjectionTestView.swift
@@ -287,7 +287,7 @@ struct TextInjectionTestView: View {
                                 )
 
                                 TroubleshootingItem(
-                                    issue: "VS Code Terminal: Text injection appears successful but text doesn't appear",
+                                    issue: "VS Code Terminal: Text injection reports success but text doesn't appear",
                                     solution: "VS Code terminal has broken Accessibility API support. Use the diagnostic tests above to confirm - Accessibility API will report success but typing simulation works. This is an Electron/VS Code bug."
                                 )
                                 

--- a/VTSApp/VTS/Views/TextInjectionTestView.swift
+++ b/VTSApp/VTS/Views/TextInjectionTestView.swift
@@ -217,6 +217,40 @@ struct TextInjectionTestView: View {
                                     )
                                 }
                             }
+                            
+                            // Diagnostic Tests
+                            VStack(alignment: .leading, spacing: 12) {
+                                Text("Method-Specific Diagnostic Tests")
+                                    .font(.subheadline)
+                                    .fontWeight(.semibold)
+                                
+                                Text("Use these tests to isolate which injection method works in different applications, BOTH require accessibility permission. NOTE: Log messages here, even if they say success, can be wrong, you need to make sure the text actually shows up where you want it to.")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                
+                                LazyVGrid(columns: [
+                                    GridItem(.flexible()),
+                                    GridItem(.flexible())
+                                ], spacing: 8) {
+                                    TestButton(
+                                        title: "🔬 Accessibility API Only",
+                                        description: "Test ONLY Accessibility API (no typing fallback)",
+                                        action: {
+                                            logMessages.add("🔬 Testing ONLY Accessibility API...")
+                                            textInjector.testAccessibilityOnlyInjection()
+                                        }
+                                    )
+                                    
+                                    TestButton(
+                                        title: "⌨️ Unicode Typing Only",
+                                        description: "Test ONLY typing simulation (no Accessibility API)",
+                                        action: {
+                                            logMessages.add("⌨️ Testing ONLY Unicode typing simulation...")
+                                            textInjector.testUnicodeTypingOnlyInjection()
+                                        }
+                                    )
+                                }
+                            }
                         }
                         .padding()
                     }
@@ -281,6 +315,11 @@ struct TextInjectionTestView: View {
                                 .font(.headline)
                             
                             VStack(alignment: .leading, spacing: 8) {
+                                TroubleshootingItem(
+                                    issue: "VS Code Terminal: Text injection appears successful but text doesn't appear",
+                                    solution: "VS Code terminal has broken Accessibility API support. Use the diagnostic tests above to confirm - Accessibility API will report success but typing simulation works. This is an Electron/VS Code bug."
+                                )
+                                
                                 TroubleshootingItem(
                                     issue: "Text not appearing in target application",
                                     solution: "Ensure the target application has focus with an active text field. Verify accessibility permission is enabled."

--- a/VTSApp/VTS/Views/TextInjectionTestView.swift
+++ b/VTSApp/VTS/Views/TextInjectionTestView.swift
@@ -72,27 +72,20 @@ struct TextInjectionTestView: View {
                                 .font(.headline)
                             
                             VStack(alignment: .leading, spacing: 8) {
-                                Text("VTS may use multiple text insertion methods for maximum app compatibility:")
+                                Text("VTS uses Unicode typing simulation for reliable text insertion across all applications:")
                                     .font(.body)
                                 
                                 VStack(alignment: .leading, spacing: 6) {
-                                    Label("Direct Text Insertion", systemImage: "1.circle.fill")
+                                    Label("Unicode Typing Simulation", systemImage: "keyboard.fill")
                                         .font(.caption)
-                                    Text("Primary method using macOS Accessibility API to directly insert text. Most reliable for standard applications.")
-                                        .font(.caption)
-                                        .foregroundColor(.secondary)
-                                        .padding(.leading, 20)
-                                    
-                                    Label("Keyboard Input Simulation", systemImage: "2.circle.fill")
-                                        .font(.caption)
-                                    Text("Fallback method that simulates typing. Supports international characters and works with specialized applications.")
+                                    Text("Primary method that simulates keyboard input with Unicode support. Works reliably with all applications, supports international characters, emojis, and complex text.")
                                         .font(.caption)
                                         .foregroundColor(.secondary)
                                         .padding(.leading, 20)
                                     
-                                    Label("Basic Key Events", systemImage: "3.circle.fill")
+                                    Label("Legacy Accessibility Methods", systemImage: "wrench.and.screwdriver.fill")
                                         .font(.caption)
-                                    Text("Final fallback using simple key simulation for maximum compatibility when other methods fail.")
+                                    Text("Available for testing and debugging purposes. These methods may not work consistently across all applications.")
                                         .font(.caption)
                                         .foregroundColor(.secondary)
                                         .padding(.leading, 20)
@@ -186,7 +179,7 @@ struct TextInjectionTestView: View {
                                     .font(.subheadline)
                                     .fontWeight(.semibold)
                                 
-                                Text("Use these tests to isolate which injection method works in different applications, BOTH require accessibility permission. NOTE: Log messages here, even if they say success, can be wrong, you need to make sure the text actually shows up where you want it to.")
+                                Text("Use these tests to diagnose and compare different injection methods. BOTH require accessibility permission. NOTE: Log messages here, even if they say success, can be wrong - you need to verify the text actually appears where expected.")
                                     .font(.caption)
                                     .foregroundColor(.secondary)
                                 

--- a/VTSApp/VTSApp.swift
+++ b/VTSApp/VTSApp.swift
@@ -183,6 +183,7 @@ class AppState: ObservableObject {
     private let notificationManager = NotificationManager.shared
     private let launchAtLoginManager = LaunchAtLoginManager.shared
     private let sparkleUpdaterManager = SparkleUpdaterManager.shared
+    private let analyticsConsentManager = AnalyticsConsentManager.shared
     private var cancellables = Set<AnyCancellable>()
     
     private var settingsWindowController: SettingsWindowController?
@@ -258,6 +259,10 @@ class AppState: ObservableObject {
     
     var sparkleUpdaterManagerService: SparkleUpdaterManager {
         return sparkleUpdaterManager
+    }
+    
+    var analyticsConsentManagerService: AnalyticsConsentManager {
+        return analyticsConsentManager
     }
     
     init() {
@@ -342,6 +347,12 @@ class AppState: ObservableObject {
             .store(in: &cancellables)
         
         sparkleUpdaterManager.objectWillChange
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+        
+        analyticsConsentManager.objectWillChange
             .sink { [weak self] _ in
                 self?.objectWillChange.send()
             }


### PR DESCRIPTION
I have tested injection in the following scenarios:

* In VS code in the commit text box, in the terminal, and in the copilot chat text box.
* Inside the GitHub issues description and title text areas.
* Replacing selected text
* Inserting when the cursor is in the middle of another text
* Inserting in the ChatGPT web textbox and it doesn't add the "Ask Anything" placeholder.
* Inserting in a text input in Slack without changing the format (links, line endings removal) of the text already inserted.

**Notes**

* Text injection does require the accessibility permission, whether you're using the accessibility API or the unicode typing simulation.
* In the future we may re-enable the accessibility way of injecting text, but only for certain applications or in the case of Google Chrome or a browser, maybe only for certain websites.

