### PR TITLE
fix: enhance error handling and enforce system prompt character limit

### DIFF
--- a/VTSApp/VTS/Services/StreamingTranscriptionService.swift
+++ b/VTSApp/VTS/Services/StreamingTranscriptionService.swift
@@ -324,6 +324,9 @@ public class StreamingTranscriptionService: ObservableObject {
         self.error = error
         isTranscribing = false
         isStreamingActive = false
+        
+        // Show notification for the error
+        notificationManager.showTranscriptionError(error)
     }
     
     // MARK: - Analytics Helper Methods
@@ -399,6 +402,10 @@ public class StreamingTranscriptionService: ObservableObject {
             case .connectionFailed(let message):
                 return STTError.networkError(message)
             case .sessionError(let message):
+                // Check for specific OpenAI prompt length error
+                if message.contains("string too long") && message.contains("prompt") {
+                    return STTError.transcriptionError("System prompt too long: \(message)")
+                }
                 return STTError.transcriptionError(message)
             case .audioStreamError(let message):
                 return STTError.audioProcessingError(message)

--- a/VTSApp/VTS/Services/StreamingTranscriptionService.swift
+++ b/VTSApp/VTS/Services/StreamingTranscriptionService.swift
@@ -404,7 +404,7 @@ public class StreamingTranscriptionService: ObservableObject {
             case .sessionError(let message):
                 // Check for specific OpenAI prompt length error
                 if message.contains("string too long") && message.contains("prompt") {
-                    return STTError.transcriptionError("System prompt too long: \(message)")
+                    return STTError.transcriptionError("System prompt too long")
                 }
                 return STTError.transcriptionError(message)
             case .audioStreamError(let message):

--- a/VTSApp/VTS/Utils/ErrorTranslator.swift
+++ b/VTSApp/VTS/Utils/ErrorTranslator.swift
@@ -109,6 +109,13 @@ public struct ErrorTranslator {
                     canRetry: false,
                     needsSettings: true
                 )
+            } else if details.contains("System prompt too long") || (details.contains("string too long") && details.contains("prompt")) {
+                return ErrorTranslation(
+                    message: "System prompt too long",
+                    hint: "Your custom prompt exceeds the 1024 character limit. Please shorten it in Settings",
+                    canRetry: false,
+                    needsSettings: true
+                )
             } else if details.contains("quota") || details.contains("billing") {
                 return ErrorTranslation(
                     message: "Account quota exceeded",

--- a/VTSApp/VTS/Utils/ErrorTranslator.swift
+++ b/VTSApp/VTS/Utils/ErrorTranslator.swift
@@ -109,10 +109,10 @@ public struct ErrorTranslator {
                     canRetry: false,
                     needsSettings: true
                 )
-            } else if details.contains("System prompt too long") || (details.contains("string too long") && details.contains("prompt")) {
+            } else if details == "System prompt too long" {
                 return ErrorTranslation(
                     message: "System prompt too long",
-                    hint: "Your custom prompt exceeds the 1024 character limit. Please shorten it in Settings",
+                    hint: "Your custom prompt exceeds the maximum character limit. Please shorten it in Settings",
                     canRetry: false,
                     needsSettings: true
                 )

--- a/VTSApp/VTS/Views/PreferencesView.swift
+++ b/VTSApp/VTS/Views/PreferencesView.swift
@@ -109,9 +109,9 @@ struct PreferencesView: View {
                                     Text("Custom Instructions:")
                                         .frame(width: 240, alignment: .leading)
                                     Spacer()
-                                    Text("\(appState.systemPrompt.count) characters")
+                                    Text("\(appState.systemPrompt.count)/\(AppState.maxSystemPromptLength) characters")
                                         .font(.caption)
-                                        .foregroundColor(.secondary)
+                                        .foregroundColor(characterCountColor(for: appState.systemPrompt.count))
                                 }
                                 
                                 ZStack(alignment: .topLeading) {
@@ -847,6 +847,19 @@ struct PreferencesView: View {
             print("Failed to delete API key: \(error)")
         }
     }
+    
+    private func characterCountColor(for count: Int) -> Color {
+        let maxLength = AppState.maxSystemPromptLength
+        let warningThreshold = Int(Double(maxLength) * 0.8) // 80% of max length
+        
+        if count >= maxLength {
+            return .red
+        } else if count >= warningThreshold {
+            return .orange
+        } else {
+            return .secondary
+        }
+    }
 }
 
 // MARK: - Keyword Management View
@@ -941,8 +954,6 @@ struct KeywordManagementView: View {
         keywords.remove(at: index)
     }
 }
-
-
 
 #Preview {
     PreferencesView(apiKeyManager: APIKeyManager())

--- a/VTSApp/VTSApp.swift
+++ b/VTSApp/VTSApp.swift
@@ -196,8 +196,14 @@ class AppState: ObservableObject {
     private let useRealtimeKey = "useRealtime"
     
     // Configuration state - now using APIKeyManager
+    public static let maxSystemPromptLength = 1024
+    
     @Published var systemPrompt = "" {
         didSet {
+            // Enforce character limit
+            if systemPrompt.count > Self.maxSystemPromptLength {
+                systemPrompt = String(systemPrompt.prefix(Self.maxSystemPromptLength))
+            }
             saveSystemPrompt()
         }
     }


### PR DESCRIPTION
Improve error handling for transcription issues and provide user-friendly messages for prompt length violations. Enforce a character limit on the system prompt and update the character count display accordingly.

Screenshot:
<img width="598" height="794" alt="image" src="https://github.com/user-attachments/assets/c1101427-c2c0-4cc0-b853-2175e1cbc8d6" />
